### PR TITLE
correctly prevent light nodes from dropping

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -80,7 +80,7 @@ for i=1, 14 do
 		light_source = i,
 		pointable = false,
 		buildable_to = true,
-		drops = {},
+		drop = {},
 		on_timer = function(pos, elapsed)
 			minetest.swap_node(pos, {name = "air"})
 		end,


### PR DESCRIPTION
The parameter name to prevent drops is currently wrong. Light nodes can drop if they are magically broken w/ e.g. TNT. 