### PR TITLE
Outdated velocity

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -103,11 +103,11 @@ end
 local function entity_pos(obj, offset)
 	offset = offset or { x=0, y=0, z=0 }
 
-	local velocity = 0
+	local velocity = { x=0, y=0, z=0 }
 	if (minetest.features.direct_velocity_on_players or not obj:is_player()) and obj.get_velocity then
-		velocity = obj:get_velocity() or 0
+		velocity = obj:get_velocity() or { x=0, y=0, z=0 }
 	else
-		velocity = obj:get_player_velocity() or 0
+		velocity = obj:get_player_velocity() or { x=0, y=0, z=0 }
 	end
 
 	return wielded_light.get_light_position(

--- a/init.lua
+++ b/init.lua
@@ -104,7 +104,7 @@ local function entity_pos(obj, offset)
 	offset = offset or { x=0, y=0, z=0 }
 
 	local velocity = 0
-	if obj.get_velocity then
+	if minetest.features.direct_velocity_on_players or not obj:is_player() then
 		velocity = obj:get_velocity() or 0
 	else
 		velocity = obj:get_player_velocity() or 0

--- a/init.lua
+++ b/init.lua
@@ -101,7 +101,15 @@ end
 
 -- Get the projected position of an entity based on its velocity, rounded to the nearest block
 local function entity_pos(obj, offset)
-	if not offset then offset = { x=0, y=0, z=0 } end
+	offset = offset or { x=0, y=0, z=0 }
+
+	local player_velocity = 0
+	if obj.get_velocity then
+		player_velocity = obj:get_velocity() or 0
+	else
+		player_velocity = obj:get_player_velocity() or 0
+	end
+
 	return wielded_light.get_light_position(
 		vector.round(
 			vector.add(
@@ -110,7 +118,7 @@ local function entity_pos(obj, offset)
 					obj:get_pos()
 				),
 				vector.multiply(
-					obj:get_player_velocity(),
+					player_velocity,
 					velocity_projection
 				)
 			)
@@ -144,7 +152,7 @@ end
 local function update_entity(entity)
 	local pos = entity_pos(entity.obj, entity.offset)
 	local pos_str = pos and minetest.pos_to_string(pos)
-	
+
 	-- If the position has changed, remove the old light and mark the entity for update
 	if entity.pos and pos_str ~= entity.pos then
 		entity.update = true
@@ -152,10 +160,10 @@ local function update_entity(entity)
 			remove_light(entity.pos, id)
 		end
 	end
-	
+
 	-- Update the recorded position
 	entity.pos = pos_str
-	
+
 	-- If the position is still loaded, pump the timer up so it doesn't get removed
 	if pos then
 		-- If the entity is marked for an update, add the light in the position if it emits light
@@ -371,7 +379,7 @@ function wielded_light.register_lightable_node(node_name, property_overrides, cu
 	lightable_nodes[node_name] = {}
 	for i=1, minetest.LIGHT_MAX do
 		local lighting_node_name = wielded_light.lighting_node_of_level(i, prefix)
-		
+
 		-- Index for quick finding later
 		lightable_nodes[node_name][i] = lighting_node_name
 		lighting_nodes[lighting_node_name] = {

--- a/init.lua
+++ b/init.lua
@@ -104,7 +104,7 @@ local function entity_pos(obj, offset)
 	offset = offset or { x=0, y=0, z=0 }
 
 	local velocity = 0
-	if minetest.features.direct_velocity_on_players or not obj:is_player() then
+	if (minetest.features.direct_velocity_on_players or not obj:is_player()) and obj.get_velocity then
 		velocity = obj:get_velocity() or 0
 	else
 		velocity = obj:get_player_velocity() or 0

--- a/init.lua
+++ b/init.lua
@@ -101,24 +101,22 @@ end
 
 -- Get the projected position of an entity based on its velocity, rounded to the nearest block
 local function entity_pos(obj, offset)
-	offset = offset or { x=0, y=0, z=0 }
-
-	local velocity = { x=0, y=0, z=0 }
+	local velocity
 	if (minetest.features.direct_velocity_on_players or not obj:is_player()) and obj.get_velocity then
-		velocity = obj:get_velocity() or { x=0, y=0, z=0 }
+		velocity = obj:get_velocity()
 	else
-		velocity = obj:get_player_velocity() or { x=0, y=0, z=0 }
+		velocity = obj:get_player_velocity()
 	end
 
 	return wielded_light.get_light_position(
 		vector.round(
 			vector.add(
 				vector.add(
-					offset,
+					offset or { x=0, y=0, z=0 },
 					obj:get_pos()
 				),
 				vector.multiply(
-					velocity,
+					velocity or { x=0, y=0, z=0 },
 					velocity_projection
 				)
 			)

--- a/init.lua
+++ b/init.lua
@@ -103,11 +103,11 @@ end
 local function entity_pos(obj, offset)
 	offset = offset or { x=0, y=0, z=0 }
 
-	local player_velocity = 0
+	local velocity = 0
 	if obj.get_velocity then
-		player_velocity = obj:get_velocity() or 0
+		velocity = obj:get_velocity() or 0
 	else
-		player_velocity = obj:get_player_velocity() or 0
+		velocity = obj:get_player_velocity() or 0
 	end
 
 	return wielded_light.get_light_position(
@@ -118,7 +118,7 @@ local function entity_pos(obj, offset)
 					obj:get_pos()
 				),
 				vector.multiply(
-					player_velocity,
+					velocity,
 					velocity_projection
 				)
 			)


### PR DESCRIPTION
After getting to test this properly on 5.3 it seems the `get_player_velocity` method only returns something useful on 5.4
This MR feature tests for `get_velocity` and also includes fallback velocity values
This would previously crash on 5.3 when you dropped an item (oops...)
This has been tested on 5.3 and definitely works now