### PR TITLE
Be more defensive in the recalc function

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -249,11 +249,20 @@ local function recalc_light(pos)
 
 	-- If the light level has changed, set the coresponding light node and initiate the cleanup timer
 	if old_value ~= max_light then
-		local node_name = lightable_nodes[name] and name or lighting_nodes[name].node
-		minetest.swap_node(pos_vec, {
-			name = lightable_nodes[node_name][max_light]
-		})
-		minetest.get_node_timer(pos_vec):start(cleanup_interval)
+		local node_name
+		if lightable_nodes[name] then
+			node_name = name
+		elseif lighting_nodes[name] then
+			node_name = lighting_nodes[name].node
+		end
+		if node_name then
+			minetest.swap_node(pos_vec, {
+				name = lightable_nodes[node_name][max_light]
+			})
+			minetest.get_node_timer(pos_vec):start(cleanup_interval)
+		else
+			active_lights[pos] = nil
+		end
 	end
 end
 


### PR DESCRIPTION
Just experienced a crash running this on the server where
`local node_name = lightable_nodes[name] and name or lighting_nodes[name].node` does not work, which means the node of `name` is not lightable or a lighting node - but still somehow has some light data associated with it.

I still can't figure out how this could happen, and the mod has been running fine for over a week, so it must be a very hard state to get into. Either way, this fix makes it more defensive and deletes the light data if no lightable node is found.

Possible causes:
- Placing a block into the position of a currently lit node
  - Tested, cannot reproduce this way
- Placing a block into a node which is about to be unlit (issue with async minetest.after)
  - Thought this through when writing it, the lighting data is kept up to date, we just trigger an update late. If this happened it would exit with `not any_light` or `max_light == 0`
- A lit node is overwritten while unloaded, possibly by worldedit
  - Can't replicate ~~Not tested, but possibly quite likely... however the lighting data does not persist so someone would had to have done this after the server last started up~~