### PR TITLE
Add a function to translate a possibly lit node to its unlit form

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -379,6 +379,14 @@ function wielded_light.get_lighting_node(node_name)
 	return lighting_nodes[node_name]
 end
 
+-- If this node is lit, return the unlit version
+function wielded_light.get_unlit_node(node)
+   if lighting_nodes[node.name] then
+      node.name = lighting_nodes[node.name].node
+   end
+   return node
+end
+
 -- Register any node as lightable, register all light level variations for it
 function wielded_light.register_lightable_node(node_name, property_overrides, custom_prefix)
 	-- Node name must be string


### PR DESCRIPTION
This adds a function that takes a minetest node table, and if it's a lit node, swaps the node.name out for the unlit version, allowing mod code to act on lit nodes as if they were their unlit selves.

On Exile, we have tall cane plants that can be lit, so you still have light when running through our thick fields of them. But having a lit node in the plant's body disrupts our dig_up function's check, so you wind up digging the plant up to the lit part and leaving the remainder floating in the air above. By passing through this utility function, I don't have to worry about whether the nodes are lit, the comparison is always unlit vs unlit.
 I tried to make the design of the function generally useful for others in the future. You can just do a minetest.get_node() and pass it through wielded_light.get_unlit_node() and go.