### PR TITLE
amend load print

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -642,3 +642,7 @@ wielded_light.register_lightable_node("default:river_water_source", nil, "river_
 
 ---TEST
 --wielded_light.register_item_light('default:dirt', 14)
+
+-- print to log after mod was loaded successfully
+print ("[MOD] Wielded Light loaded")
+


### PR DESCRIPTION
Add a final **print to log** at the end of `init.lua` to indicate the mod was loaded successfully. This idea was derived from other mods which are specifically aimed at MT servers.

This could be useful not only for player support (e.g. in the MT forum) but would certainly be useful for MT server admins using the CLI and reading their server logs.