### PR TITLE
Added builtin_item as an optional dependency

### DIFF
--- a/mod.conf
+++ b/mod.conf
@@ -1,2 +1,2 @@
 name = wielded_light
-optional_depends = default, hades_core
+optional_depends = default, hades_core, builtin_item


### PR DESCRIPTION
Per a conversation here:
https://content.minetest.net/threads/4470/

This ensured builtin_item loads first and then wielded_light can affect the torches properly. Without this, held torches may illuminate, but dropped torches will not.