### PR TITLE
Add support for offhand

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -176,6 +176,20 @@ local function update_entity(entity)
 	if pos then
 		-- If the entity is marked for an update, add the light in the position if it emits light
 		if entity.update then
+			-- Offhand
+			if core.get_modpath("mcl_offhand") then
+				local ohis = mcl_offhand.get_offhand(entity.obj)
+				if ohis:get_name() ~= "" then
+					local level = ohis:get_definition().light_source
+					local id = "offhand"
+					if level > 0 then
+						add_light(pos_str, id, level)
+					else
+						remove_light(pos_str, id)
+					end
+				end
+			end
+			-- Items
 			for id, item in pairs(entity.items) do
 				if item.level > 0 and not (item.floodable and is_lightable_liquid(pos)) then
 					add_light(pos_str, id, item.level)

--- a/init.lua
+++ b/init.lua
@@ -176,18 +176,6 @@ local function update_entity(entity)
 	if pos then
 		-- If the entity is marked for an update, add the light in the position if it emits light
 		if entity.update then
-			-- Offhand
-			local ohis = entity.obj:get_inventory():get_stack("offhand", 1) -- Get offhand item stack (nil if empty or unavailable)
-			if ohis:get_name() ~= "" then
-				local level = ohis:get_definition().light_source
-				local id = "offhand"
-				if level > 0 then
-					add_light(pos_str, id, level)
-				else
-					remove_light(pos_str, id)
-				end
-			end
-			-- Items
 			for id, item in pairs(entity.items) do
 				if item.level > 0 and not (item.floodable and is_lightable_liquid(pos)) then
 					add_light(pos_str, id, item.level)
@@ -671,6 +659,7 @@ minetest.register_entity(":__builtin:item", item)
 -- Track a player's wielded item
 wielded_light.register_player_lightstep(function (player)
 	wielded_light.track_user_entity(player, "wield", player:get_wielded_item():get_name())
+	wielded_light.track_user_entity(player, "offhand", player:get_inventory():get_stack("offhand", 1):get_name())
 end)
 
 -- Register helper nodes

--- a/init.lua
+++ b/init.lua
@@ -177,16 +177,14 @@ local function update_entity(entity)
 		-- If the entity is marked for an update, add the light in the position if it emits light
 		if entity.update then
 			-- Offhand
-			if core.get_modpath("mcl_offhand") then
-				local ohis = mcl_offhand.get_offhand(entity.obj)
-				if ohis:get_name() ~= "" then
-					local level = ohis:get_definition().light_source
-					local id = "offhand"
-					if level > 0 then
-						add_light(pos_str, id, level)
-					else
-						remove_light(pos_str, id)
-					end
+			local ohis = entity.obj:get_inventory():get_stack("offhand", 1) -- Get offhand item stack (nil if empty or unavailable)
+			if ohis:get_name() ~= "" then
+				local level = ohis:get_definition().light_source
+				local id = "offhand"
+				if level > 0 then
+					add_light(pos_str, id, level)
+				else
+					remove_light(pos_str, id)
 				end
 			end
 			-- Items

--- a/mod.conf
+++ b/mod.conf
@@ -1,2 +1,2 @@
 name = wielded_light
-optional_depends = default, hades_core, builtin_item, mcl_offhand
+optional_depends = default, hades_core, builtin_item

--- a/mod.conf
+++ b/mod.conf
@@ -1,2 +1,2 @@
 name = wielded_light
-optional_depends = default, hades_core, builtin_item
+optional_depends = default, hades_core, builtin_item, mcl_offhand


### PR DESCRIPTION
`update_entity` now also checks if there is a light emitting item in the offhand using `mcl_offhand`. Note that I used `offhand` for the ID. I wasn't sure what ID was for, so that might be wrong. It seemed to work in multiplayer tough.

Tested on MTG (Minetest Game) for something that doesn't have `mcl_offhand` and Mineclonia for something that has.